### PR TITLE
#13 イベント登録機能を追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,11 +70,15 @@ gem 'bootstrap', '~> 4.3.1'
 gem 'jquery-rails'
 
 # font-awesome
-gem 'font-awesome-sass', '~> 5.9.0'
+gem "font-awesome-rails" # カレンダーで使う
+gem 'font-awesome-sass', '~> 5.9.0' # 種類が多いので基本的にはこっちを使う
 
 # カレンダー
 gem 'fullcalendar-rails'
 gem 'momentjs-rails'
 
 # タグ機能
-gem 'acts-as-taggable-on' 
+gem 'acts-as-taggable-on'
+
+# 日付時刻入力用
+gem "bootstrap4-datetime-picker-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,6 +58,10 @@ GEM
       autoprefixer-rails (>= 9.1.0)
       popper_js (>= 1.14.3, < 2)
       sassc-rails (>= 2.0.0)
+    bootstrap4-datetime-picker-rails (0.3.1)
+      jquery-rails (~> 4.2, >= 4.2.0)
+      moment-timezone-rails (~> 1.0)
+      momentjs-rails (>= 2.10.5, <= 3.0.0)
     builder (3.2.3)
     byebug (11.0.1)
     capybara (3.29.0)
@@ -86,6 +90,8 @@ GEM
     erubi (1.8.0)
     execjs (2.7.0)
     ffi (1.11.1)
+    font-awesome-rails (4.7.0.5)
+      railties (>= 3.2, < 6.1)
     font-awesome-sass (5.9.0)
       sassc (>= 1.11)
     fullcalendar-rails (3.9.0.0)
@@ -121,6 +127,8 @@ GEM
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
+    moment-timezone-rails (1.0.0)
+      momentjs-rails (>= 2.10.5, <= 3.0.0)
     momentjs-rails (2.20.1)
       railties (>= 3.1)
     msgpack (1.3.1)
@@ -231,10 +239,12 @@ DEPENDENCIES
   acts-as-taggable-on
   bootsnap (>= 1.1.0)
   bootstrap (~> 4.3.1)
+  bootstrap4-datetime-picker-rails
   byebug
   capybara (>= 2.15)
   chromedriver-helper
   coffee-rails (~> 4.2)
+  font-awesome-rails
   font-awesome-sass (~> 5.9.0)
   fullcalendar-rails
   jbuilder (~> 2.5)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -19,16 +19,3 @@
 //= require fullcalendar
 //= require fullcalendar/lang/ja
 //= require_tree .
-
-$(function() {
-  $(document).on("turbolinks:load", function() {
-    $("#calendar").fullCalendar({
-      lang: "ja",
-      header: {
-        left: "month,agendaWeek,agendaDay",
-        center: "title",
-        right: "prev,next today"
-      }
-    });
-  });
-});

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -18,4 +18,5 @@
 //= require moment
 //= require fullcalendar
 //= require fullcalendar/lang/ja
+//= require tempusdominus-bootstrap-4.js
 //= require_tree .

--- a/app/assets/javascripts/calendar.js
+++ b/app/assets/javascripts/calendar.js
@@ -14,10 +14,17 @@ $(function() {
 
           $("#calendar").fullCalendar({
             lang: "ja",
+            timeFormat: "HH:mm", // 24時間表記にする
             header: {
               left: "month,agendaWeek,agendaDay",
               center: "title",
               right: "prev,next today"
+            },
+            displayEventEnd: {
+              // 終了時間を表示
+              month: true,
+              basicWeek: false,
+              default: true
             },
             events: event // 受け取ったjsonの中身全部表示
           });

--- a/app/assets/javascripts/calendar.js
+++ b/app/assets/javascripts/calendar.js
@@ -1,0 +1,30 @@
+$(function() {
+  $(document).on("turbolinks:load", function() {
+    var data = new Array();
+
+    // ゲームのshowページを表示したとき
+    if (window.location.href.match(/\/games\/\d+/)) {
+      $.ajax({
+        type: "GET",
+        url: window.location.href, // 通信先のURL
+        dataType: "json"
+      })
+        .done(function(event) {
+          alert("ok");
+
+          $("#calendar").fullCalendar({
+            lang: "ja",
+            header: {
+              left: "month,agendaWeek,agendaDay",
+              center: "title",
+              right: "prev,next today"
+            },
+            events: event // 受け取ったjsonの中身全部表示
+          });
+        })
+        .fail(function(event) {
+          alert("ng");
+        });
+    }
+  });
+});

--- a/app/assets/javascripts/calendar.js
+++ b/app/assets/javascripts/calendar.js
@@ -8,30 +8,30 @@ $(function() {
         type: "GET",
         url: window.location.href, // 通信先のURL
         dataType: "json"
-      })
-        .done(function(event) {
-          alert("ok");
-
-          $("#calendar").fullCalendar({
-            lang: "ja",
-            timeFormat: "HH:mm", // 24時間表記にする
-            header: {
-              left: "month,agendaWeek,agendaDay",
-              center: "title",
-              right: "prev,next today"
-            },
-            displayEventEnd: {
-              // 終了時間を表示
-              month: true,
-              basicWeek: false,
-              default: true
-            },
-            events: event // 受け取ったjsonの中身全部表示
+      }).done(function(event) {
+        $(document)
+          .ready(function() {
+            $("#calendar").fullCalendar({
+              lang: "ja",
+              timeFormat: "HH:mm", // 24時間表記にする
+              header: {
+                left: "month,agendaWeek,agendaDay",
+                center: "title",
+                right: "prev,next today"
+              },
+              displayEventEnd: {
+                // 終了時間を表示
+                month: true,
+                basicWeek: false,
+                default: true
+              },
+              events: event // 受け取ったjsonの中身全部表示
+            });
+          })
+          .fail(function(event) {
+            alert("ng");
           });
-        })
-        .fail(function(event) {
-          alert("ng");
-        });
+      });
     }
   });
 });

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -11,3 +11,4 @@
 @import "config/*";
 @import "modules/*";
 @import "override/*";
+@import "tempusdominus-bootstrap-4.css";

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,0 +1,20 @@
+class EventsController < ApplicationController
+  def new
+    @game = Game.find(params[:game_id])
+    @event = Event.new
+  end
+
+  def create
+    Event.create(event_params)
+    redirect_to game_path(id: game_params[:game_id])
+  end
+
+  private
+  def event_params
+    params.require(:event).permit(:title, :start, :end).merge(game_id: params[:game_id])
+  end
+
+  def game_params
+    params.permit(:game_id)
+  end
+end

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -38,6 +38,6 @@ class GamesController < ApplicationController
 
   private
   def game_params
-    params.require(:game).permit(:name, :tag_list)
+    params.require(:game).permit(:name, :color, :textColor, :tag_list)
   end
 end

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -25,7 +25,12 @@ class GamesController < ApplicationController
   end
 
   def show
-    @game = Game.find(params[:id])
+    @game   = Game.find(params[:id])
+    @events = @game.events
+    respond_to do |format|
+      format.html
+      format.json
+    end
   end
 
   def search

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,0 +1,3 @@
+class Event < ApplicationRecord
+  belongs_to :game
+end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -1,4 +1,6 @@
 class Game < ApplicationRecord
   # タグ機能を付ける
   acts_as_taggable
+
+  has_many :events
 end

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -1,0 +1,23 @@
+<div class="row">
+  <div class="card mt-2 w-100">
+    <div class="card-body">
+
+      <%= form_with model: [ @game, @event ], class: "form-group" do |f| %>
+        <%= f.label      :title, 'タイトル', class: "text-muted mb-1" %>
+        <%= f.text_field :title, class: "form-control mb-2", placeholder: "イベント・キャンペーン名を入力してください" %>
+
+        <%= f.label      :start, '開始日時', class: "text-muted mb-1" %>
+        <%= f.text_field :start, class: "form-control datetimepicker-input mb-2", placeholder: "クリックでカレンダー入力ができます",
+          id: "start", data: {toggle: "datetimepicker", target: "#start"} %>
+
+        <%= f.label      :end,   '終了日時', class: "text-muted mb-1" %>
+        <%= f.text_field :end, class: "form-control datetimepicker-input mb-2", placeholder: "クリックでカレンダー入力ができます",
+          id: "end", data: {toggle: "datetimepicker", target: "#end"} %>
+
+        <%= button_tag type: 'submit', class: "btn btn-okColor w-100" do %>
+          <%= fa_icon "plus" %> 登録する
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/games/edit.html.erb
+++ b/app/views/games/edit.html.erb
@@ -1,15 +1,25 @@
 <div class="card mt-2">
   <div class="card-body">
     <%= form_with model: @game, class: "form-group" do |f| %>
-      <%= f.label      :name, 'タイトル', class: "text-muted mb-1" %>
-      <%= f.text_field :name,            class: "form-control mb-2", placeholder: "正式名称で入力してください / 例：Fate/Grand Order" %>
+    <%= f.label      :name, 'タイトル', class: "text-muted mb-1" %>
+    <%= f.text_field :name, class: "form-control mb-2", placeholder: "正式名称で入力してください / 例：Fate/Grand Order" %>
 
-      <%= f.label :tag_list, '検索用ワード', class: "text-muted mb-1" %>
-      <%= f.text_field :tag_list, value: @game.tag_list.join(' '),
-        class: "form-control mb-2", placeholder: "半角スペース区切りで略称等を入力してください / 例：Fate FGO" %>
+    <%= f.label :tag_list, '検索用ワード', class: "text-muted mb-1" %>
+    <%= f.text_field :tag_list, value: @game.tag_list.join(' '), class: "form-control mb-2", placeholder: "半角スペース区切りで略称等を入力してください / 例：Fate FGO" %>
 
-      <%= button_tag type: 'submit', class: "btn btn-okColor w-100" do %>
-        <%= icon('fas', 'plus') %> 登録する
+    <div class="form-row mb-2">
+      <div class="col">
+        <%= f.label      :color, 'イメージカラー', class: "text-muted mb-1" %>
+        <%= f.text_field :color, class: "form-control mb-2",placeholder: "カレンダー表示時の背景色になります。/ 例： #cccccc" %>
+      </div>
+      <div class="col">
+        <%= f.label      :textColor, 'テキストカラー', class: "text-muted mb-1" %>
+        <%= f.text_field :textColor, class: "form-control mb-2", placeholder: "カレンダー表示時の文字色になります。/ 例： #ffffff" %>
+      </div>
+    </div>
+
+    <%= button_tag type: 'submit', class: "btn btn-okColor w-100" do %>
+      <%= icon('fas', 'plus') %> 登録する
       <% end %>
     <% end %>
   </div>

--- a/app/views/games/index.html.erb
+++ b/app/views/games/index.html.erb
@@ -1,9 +1,4 @@
 <div class="row">
-  テストページ
-</div>
-
-<div class="row">
-  <div id="calendar"></div>
   <ul class="list-group" style="max-width: 400px;">
     <% @games.each do |game| %>
       <li class="list-group-item">
@@ -13,4 +8,25 @@
       </li>
     <% end %>
   </ul>
-</div> 
+</div>
+
+<div class="row">
+  <div class="card mt-2 w-100">
+    <div class="card-body p-20">
+      <h5 class="card-title font-weight-bold">検索</h2>
+      <p class="card-text mb-3 text-muted">
+        略称(キーワード)検索がご利用いただけます。</br>
+        例：Fate/Grand Order は、「FGO」「フェイト」等でもヒットします。
+      </p>
+      <h5 class="card-title font-weight-bold">それでも見つからない場合…</h2>
+      <p class="card-text mb-2 text-muted">
+        下記「登録する」ボタンより、新規ゲームを登録することができます。
+      </p>
+        <%= link_to new_game_path do %>
+          <%= button_tag "登録する", type: 'button', class: "btn btn-okColor w-100" do %>
+            <%= icon('fas', 'plus') %> 登録する
+          <% end %>
+        <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/games/index.html.erb
+++ b/app/views/games/index.html.erb
@@ -24,7 +24,7 @@
       </p>
         <%= link_to new_game_path do %>
           <%= button_tag "登録する", type: 'button', class: "btn btn-okColor w-100" do %>
-            <%= icon('fas', 'plus') %> 登録する
+            <%= fa_icon "plus" %> 登録する
           <% end %>
         <% end %>
     </div>

--- a/app/views/games/new.html.erb
+++ b/app/views/games/new.html.erb
@@ -1,15 +1,27 @@
-<div class="card mt-2">
-  <div class="card-body">
-    <%= form_with model: @game, class: "form-group" do |f| %>
-      <%= f.label      :name, 'タイトル', class: "text-muted mb-1" %>
-      <%= f.text_field :name,            class: "form-control mb-2", placeholder: "正式名称で入力してください / 例：Fate/Grand Order" %>
+<div class="row">
+  <div class="card mt-2 w-100">
+    <div class="card-body">
+      <%= form_with model: @game, class: "form-group" do |f| %>
+        <%= f.label      :name, 'タイトル', class: "text-muted mb-1" %>
+        <%= f.text_field :name, class: "form-control mb-2", placeholder: "正式名称で入力してください / 例：Fate/Grand Order" %>
 
-      <%= f.label :tag_list, '検索用ワード', class: "text-muted mb-1" %>
-      <%= f.text_field :tag_list, value: @game.tag_list.join(','), class: "form-control mb-2", placeholder: "半角スペース区切りで略称等を入力してください / 例：Fate, FGO" %>
+        <%= f.label :tag_list, '検索用ワード', class: "text-muted mb-1" %>
+        <%= f.text_field :tag_list, value: @game.tag_list.join(' '), class: "form-control mb-2", placeholder: "半角スペース区切りで略称等を入力してください / 例：Fate FGO" %>
 
-      <%= button_tag type: 'submit', class: "btn btn-okColor w-100" do %>
-        <%= icon('fas', 'plus') %> 登録する
+        <div class="form-row mb-2">
+          <div class="col">
+            <%= f.label      :color, 'イメージカラー', class: "text-muted mb-1" %>
+            <%= f.text_field :color, class: "form-control mb-2",placeholder: "カレンダー表示時の背景色になります。/ 例： #cccccc" %>
+          </div>
+          <div class="col">
+            <%= f.label      :textColor, 'テキストカラー', class: "text-muted mb-1" %>
+            <%= f.text_field :textColor, class: "form-control mb-2", placeholder: "カレンダー表示時の文字色になります。/ 例： #ffffff" %>
+          </div>
+        </div>
+        <%= button_tag type: 'submit', class: "btn btn-okColor w-100" do %>
+          <%= icon('fas', 'plus') %> 登録する
+        <% end %>
       <% end %>
-    <% end %>
+    </div>
   </div>
 </div>

--- a/app/views/games/new.html.erb
+++ b/app/views/games/new.html.erb
@@ -19,7 +19,7 @@
           </div>
         </div>
         <%= button_tag type: 'submit', class: "btn btn-okColor w-100" do %>
-          <%= icon('fas', 'plus') %> 登録する
+          <%= fa_icon "plus" %> 登録する
         <% end %>
       <% end %>
     </div>

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -3,16 +3,17 @@
     <%= @game.name %>
   </h3>
   <%= link_to edit_game_path(@game) do %>
-    <%= icon('fas', 'wrench', class: "pt-2 pl-2") %>
+    <%= fa_icon "wrench", class: "pt-2 pl-2" %>
+  <% end %>
+  <%= link_to new_game_event_path(@game) do %>
+    <%= fa_icon "plus", class: "pt-2 pl-2" %>
   <% end %>
 </div>
 
 <div class="row mb-3">
   <ul class="list-inline">
     <% @game.tag_list.each do |tag| %>
-      <li class="list-inline-item badge badge-color">
-        <%= tag %>
-      </li>
+      <li class="list-inline-item badge badge-color"><%= tag %></li>
     <% end %>
   </ul>
 </div>

--- a/app/views/games/show.json.jbuilder
+++ b/app/views/games/show.json.jbuilder
@@ -1,0 +1,6 @@
+json.array! @events do |event|
+  json.title  event.title
+  json.start  event.start
+  json.end    event.end
+  json.allDay event.allDay
+end 

--- a/app/views/games/show.json.jbuilder
+++ b/app/views/games/show.json.jbuilder
@@ -3,6 +3,6 @@ json.array! @events do |event|
   json.start     event.start
   json.end       event.end
   json.allDay    event.allDay
-  json.color     "#ff99cc"
-  json.textColor "#ffffff"
+  json.color     @game.color
+  json.textColor @game.textColor
 end

--- a/app/views/games/show.json.jbuilder
+++ b/app/views/games/show.json.jbuilder
@@ -1,6 +1,8 @@
 json.array! @events do |event|
-  json.title  event.title
-  json.start  event.start
-  json.end    event.end
-  json.allDay event.allDay
-end 
+  json.title     event.title
+  json.start     event.start
+  json.end       event.end
+  json.allDay    event.allDay
+  json.color     "#ff99cc"
+  json.textColor "#ffffff"
+end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -8,33 +8,36 @@
     <ul class="navbar-nav">
       <li class="nav-item active">
         <%= link_to root_path, class: "nav-link" do %>
-          <%= icon('fas', 'home') %> ホーム
+          <%= fa_icon "home" %> ホーム
           <span class="sr-only"></span>
         <% end %>
       </li>
+
       <li class="nav-item">
         <a class="nav-link" href="#">
-          <%= icon('fas', 'heart') %> お気に入り
+          <%= fa_icon "heart" %> お気に入り
         </a>
       </li>
       <li class="nav-item">
-        <%= link_to games_path, class: "nav-link" do %>
-          <%= icon('fas', 'search-plus') %> さがす
+        <%= link_to search_games_path, class: "nav-link" do %>
+          <%= fa_icon "search-plus" %> さがす
         <% end %>
       </li>
+
+
       <li class="nav-item">
         <a class="nav-link" href="#">
-          <%= icon('fas', 'cog') %> アカウント設定
+          <%= fa_icon "cog" %> アカウント設定
         </a>
       </li>
       <li class="nav-item">
         <a class="nav-link" href="#">
-          <%= icon('fas', 'question') %> ヘルプ
+          <%= fa_icon "question" %> ヘルプ
         </a>
       </li>
       <li class="nav-item">
         <a class="nav-link" href="#">
-          <%= icon('fas', 'sign-out-alt') %> ログアウト
+          <%= fa_icon "sign-out" %> ログアウト
         </a>
       </li>
     </ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   root 'games#index'
 
   resources  :games,  except: [:destroy] do
+    resources :events, only: [:new, :create]
     collection do
       get 'search'
     end

--- a/db/migrate/20190924024535_create_events.rb
+++ b/db/migrate/20190924024535_create_events.rb
@@ -1,0 +1,13 @@
+class CreateEvents < ActiveRecord::Migration[5.2]
+  def change
+    create_table :events do |t|
+      t.references :game, foreign_key: true
+      t.string     :title, null: false
+      t.datetime   :start, null: false
+      t.datetime   :end,   null: false
+      t.boolean    :allDay
+      t.timestamps
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190924025628_add_color_to_games.rb
+++ b/db/migrate/20190924025628_add_color_to_games.rb
@@ -1,0 +1,6 @@
+class AddColorToGames < ActiveRecord::Migration[5.2]
+  def change
+    add_column :games, :color, :string, null: false
+    add_column :games, :textColor, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_24_024535) do
+ActiveRecord::Schema.define(version: 2019_09_24_025628) do
 
   create_table "events", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "game_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,25 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_22_071762) do
+ActiveRecord::Schema.define(version: 2019_09_24_024535) do
+
+  create_table "events", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "game_id"
+    t.string "title", null: false
+    t.datetime "start", null: false
+    t.datetime "end", null: false
+    t.boolean "allDay"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["game_id"], name: "index_events_on_game_id"
+  end
 
   create_table "games", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "color", null: false
+    t.string "textColor", null: false
     t.index ["name"], name: "index_games_on_name", unique: true
   end
 
@@ -44,4 +57,5 @@ ActiveRecord::Schema.define(version: 2019_09_22_071762) do
     t.index ["name"], name: "index_tags_on_name", unique: true
   end
 
+  add_foreign_key "events", "games"
 end


### PR DESCRIPTION
# What
- ゲームごとに、イベントを登録できるようにする
- ゲームごとに、イベントの背景色と文字色を登録できるようにする
- 日付と時間は、カレンダーから入力できるようにする

# Why
- カレンダーに、イベントを表示できるようにするため
- カレンダーの視認性向上のため(表示するイベントが全て同じ色だと、区別がつかない)
- ユーザビリティ向上のため(手入力で時刻まで入力するのは面倒、入力ミスも発生しやすい)

Close #13 