### PR TITLE
#38 細かい修正：タグ付け、テーブル関連付けの修正

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -7,18 +7,19 @@ class GamesController < ApplicationController
   end
 
   def new
-    @game = Game.new
+    @colors = Color.order("id ASC")
+    @game   = Game.new
   end
 
   def create
     @game = Game.new(game_params)
-    @game.tag_list.add(@game.name) # タグリストに、名前を追加する
     @game.save
     redirect_to :root
   end
 
   def edit
-    @game = Game.find(params[:id])
+    @colors = Color.order("id ASC")
+    @game   = Game.find(params[:id])
   end
 
   def update
@@ -48,16 +49,18 @@ class GamesController < ApplicationController
 
   private
   def game_params
-    params.require(:game).permit(:name, :color, :textColor, :tag_list)
+    params.require(:game).permit(:name, :color_id, :textColor, :tag_list)
   end
 
   def move_to_index
     # idがあればゲームの個別ページへ
     # idがなければ(new)ルートパスへ
-    if params[:id]
-      redirect_to action: :show, id: params[:id] unless user_signed_in?
-    else
-      redirect_to root_path
+    unless user_signed_in?
+      if params[:id]
+        redirect_to action: :show, id: params[:id]
+      else
+        redirect_to root_path
+      end
     end
   end
 end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -2,10 +2,10 @@ class Game < ApplicationRecord
   # タグ機能を付ける
   acts_as_taggable
 
-  has_many :events
+  has_many :events, dependent: :destroy
 
   # Gameモデルはfavoritesとつながる
-  has_many :favorites
+  has_many :favorites, dependent: :destroy
 
   # GameモデルはFavoriteを通して、複数のUserモデルとつながる
   has_many :users, through: :favorites


### PR DESCRIPTION
# What
- ゲーム削除時、イベントとお気に入りテーブルも同時に削除
- タグリストに、ゲーム名と同じ名前は登録しない

# Why
- 現時点でゲーム削除機能はないが、データの整合性を取っていくため
- 当初、タグでのみ検索していた都合上、ゲーム名と同じタグを登録するようになっていたため
  - 現在はゲーム名とタグで検索させているため、不要になった

Close #38